### PR TITLE
fix(css): correct custom property names in sidebar theme

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -10,7 +10,7 @@
         "Instrument Sans", ui-sans-serif, system-ui, sans-serif,
         "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
         "Noto Color Emoji";
-    --sidebar-background: hsl(var(--sidebar-wbackground));
+    --sidebar-background: hsl(var(--sidebar-background));
     --sidebar-foreground: hsl(var(--sidebar-foreground));
     --sidebar-accent: hsl(var(--sidebar-accent));
     --sidebar-accent-foreground: hsl(var(--sidebar-accent-foreground));
@@ -21,6 +21,10 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @layer components {
+    .bg-sidebar {
+        background-color: hsl(var(--sidebar-background));
+    }
+    
     .bg-sidebar-accent {
         background-color: hsl(var(--sidebar-accent));
     }


### PR DESCRIPTION
## Summary

This PR fixes incorrect custom property references used in the sidebar theme configuration. The issue caused the background colors to not reflect the expected light/dark theme values.

## Changes

- Corrected the use of `--sidebar-wbackground` to `--sidebar-background` and similar custom property names inside `@theme`.
- Added a missing `.bg-sidebar` class to support the `--sidebar-background` variable.

## Before and After

### 🔆 Light Mode

**Before:**
![image](https://github.com/user-attachments/assets/ddc527c5-e5bb-4d61-b64c-587153e10d70)

**After:**
![image](https://github.com/user-attachments/assets/0c772b8a-5145-4901-a500-2344571df3ae)

### 🌙 Dark Mode

**Before:**
![image](https://github.com/user-attachments/assets/f474f652-b24e-4687-8b72-919437352427)

**After:**
![image](https://github.com/user-attachments/assets/bfe427d2-d6d7-40aa-bccf-e8b2eb347ed0)

## Notes

Let me know if you'd prefer a different naming convention for the utility class `.bg-sidebar` or any adjustments. Thanks!