### PR TITLE
fix: persist sidebar state using local Storage

### DIFF
--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -38,8 +38,11 @@
 </head>
 
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200 antialiased" x-data="{
-    sidebarOpen: window.innerWidth >= 1024,
-    toggleSidebar() { this.sidebarOpen = !this.sidebarOpen },
+    sidebarOpen: localStorage.getItem('sidebarOpen') === null ? window.innerWidth >= 1024 : localStorage.getItem('sidebarOpen') === 'true',
+    toggleSidebar() { 
+        this.sidebarOpen = !this.sidebarOpen;
+        localStorage.setItem('sidebarOpen', this.sidebarOpen);
+    },
     formSubmitted: false,
 }">
 


### PR DESCRIPTION
This PR persists the sidebar's collapsed/expanded state using `localStorage`, so it remains consistent across page reloads. 
