### PR TITLE
Fix svgs in sidebar being white on white on dark mode

### DIFF
--- a/resources/views/components/layouts/sidebar-link.blade.php
+++ b/resources/views/components/layouts/sidebar-link.blade.php
@@ -5,7 +5,7 @@
         'bg-sidebar-accent text-sidebar-accent-foreground font-medium' => $active,
         'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground text-sidebar-foreground' => !$active,
     ])>
-        @svg($icon, $active ? 'w-5 h-5 text-white' : 'w-5 h-5 text-gray-500')
+        @svg($icon, $active ? 'w-5 h-5 text-white dark:text-gray-800' : 'w-5 h-5 text-gray-500')
         <span :class="{ 'hidden ml-0': !sidebarOpen, 'ml-3': sidebarOpen }"
             x-transition:enter="transition-opacity duration-300" x-transition:enter-start="opacity-0"
             x-transition:enter-end="opacity-100" x-transition:leave="transition-opacity duration-300"

--- a/resources/views/components/layouts/sidebar-three-level-parent.blade.php
+++ b/resources/views/components/layouts/sidebar-three-level-parent.blade.php
@@ -14,7 +14,7 @@
         'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground text-sidebar-foreground' => !$active,
     ])>
         <div class="flex items-center">
-            @svg($icon, $active ? 'w-5 h-5 text-white' : 'w-5 h-5 text-gray-500')
+            @svg($icon, $active ? 'w-5 h-5 text-white dark:text-gray-800' : 'w-5 h-5 text-gray-500')
             <span :class="{ 'opacity-0 hidden ml-0': !sidebarOpen, 'ml-3': sidebarOpen }"
                 class="transition-opacity duration-300">{{ $title }}</span>
         </div>

--- a/resources/views/components/layouts/sidebar-two-level-link-parent.blade.php
+++ b/resources/views/components/layouts/sidebar-two-level-link-parent.blade.php
@@ -14,7 +14,7 @@
         'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground text-sidebar-foreground' => !$active,
     ])>
         <div class="flex items-center">
-            @svg($icon, $active ? 'w-5 h-5 text-white' : 'w-5 h-5 text-gray-500')
+            @svg($icon, $active ? 'w-5 h-5 text-white dark:text-gray-800' : 'w-5 h-5 text-gray-500')
             <span :class="{ 'opacity-0 hidden ml-0': !sidebarOpen, 'ml-3': sidebarOpen }"
                 class="transition-opacity duration-300">{{ $title }}</span>
         </div>


### PR DESCRIPTION
Fix dark theme, sidebar SVG icons being white in dark theme.

Here is what it looked like before.
![Screenshot 2025-07-07 at 15 38 11](https://github.com/user-attachments/assets/6a33140e-6a5c-42b2-a466-cf1139ecff8c)

Here is what it looks like with the update.
![Screenshot 2025-07-07 at 15 30 16](https://github.com/user-attachments/assets/127a02b8-c2f3-4637-a280-1351ad98f059)
