### PR TITLE
Style improvements for auth pages

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -3,30 +3,29 @@
     <div
         class="bg-white dark:bg-gray-800 rounded-lg shadow-md border border-gray-200 dark:border-gray-700 overflow-hidden">
         <div class="p-6">
-            <div class="text-center mb-6">
-                <h1 class="text-2xl font-bold text-gray-800 dark:text-gray-100">{{ __('Login') }}</h1>
-                <p class="text-gray-600 dark:text-gray-400 mt-1">Sign in to your account</p>
+            <div class="mb-3">
+                <h1 class="text-2xl font-bold text-gray-800 dark:text-gray-100">{{ __('Log in to your account') }}</h1>
             </div>
 
-            <form method="POST" action="{{ route('login') }}">
+            <form method="POST" action="{{ route('login') }}" class="space-y-3">
                 @csrf
                 <!-- Email Input -->
-                <div class="mb-4">
+                <div>
                     <x-forms.input label="Email" name="email" type="email" placeholder="your@email.com" />
                 </div>
 
                 <!-- Password Input -->
-                <div class="mb-4">
+                <div>
                     <x-forms.input label="Password" name="password" type="password" placeholder="••••••••" />
-                    @if (Route::has('password.request'))
-                        <a href="{{ route('password.request') }}"
-                            class="text-xs text-blue-600 dark:text-blue-400 hover:underline">{{ __('Forgot password?') }}</a>
-                    @endif
-                </div>
 
-                <!-- Remember Me -->
-                <div class="mb-6">
-                    <x-forms.checkbox label="Remember me" name="remember" />
+                    <!-- Remember me & password reset -->
+                    <div class="flex items-center justify-between mt-2">
+                        @if (Route::has('password.request'))
+                            <a href="{{ route('password.request') }}"
+                                class="text-xs text-blue-600 dark:text-blue-400 hover:underline">{{ __('Forgot password?') }}</a>
+                        @endif
+                        <x-forms.checkbox label="Remember me" name="remember" />
+                    </div>
                 </div>
 
                 <!-- Login Button -->

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -2,32 +2,29 @@
     <div
         class="bg-white dark:bg-gray-800 rounded-lg shadow-md border border-gray-200 dark:border-gray-700 overflow-hidden">
         <div class="p-6">
-            <div class="text-center mb-6">
-                <h1 class="text-2xl font-bold text-gray-800 dark:text-gray-100">{{ __('Register') }}</h1>
-                <p class="text-gray-600 dark:text-gray-400 mt-1">
-                    {{ __('Enter your details below to create your account') }}
-                </p>
+            <div class="mb-3">
+                <h1 class="text-2xl font-bold text-gray-800 dark:text-gray-100">{{ __('Register an account') }}</h1>
             </div>
 
-            <form method="POST" action="{{ route('register') }}">
+            <form method="POST" action="{{ route('register') }}" class="space-y-3">
                 @csrf
                 <!-- Full Name Input -->
-                <div class="mb-4">
+                <div>
                     <x-forms.input label="Full Name" name="name" type="text" placeholder="{{ __('Full Name') }}" />
                 </div>
 
                 <!-- Email Input -->
-                <div class="mb-4">
+                <div>
                     <x-forms.input label="Email" name="email" type="email" placeholder="your@email.com" />
                 </div>
 
                 <!-- Password Input -->
-                <div class="mb-4">
+                <div>
                     <x-forms.input label="Password" name="password" type="password" placeholder="••••••••" />
                 </div>
 
                 <!-- Confirm Password Input -->
-                <div class="mb-4">
+                <div>
                     <x-forms.input label="Confirm Password" name="password_confirmation" type="password"
                         placeholder="••••••••" />
                 </div>

--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -6,7 +6,7 @@
 
 @php
     $styleClasses = \Illuminate\Support\Arr::toCssClasses([
-        'text-white font-medium py-2 px-4 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2 transition-colors flex items-center justify-center',
+        'text-white font-medium py-2 px-4 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2 transition-colors flex items-center justify-center cursor-pointer',
         match ($type) {
             'primary' => 'bg-blue-600 hover:bg-blue-700 focus:ring-blue-500',
             'danger' => 'bg-red-600 hover:bg-red-700 focus:ring-red-500',

--- a/resources/views/components/forms/checkbox.blade.php
+++ b/resources/views/components/forms/checkbox.blade.php
@@ -1,10 +1,10 @@
 @props(['label', 'name', 'value' => null])
 
 <label for="{{ $name }}"
-    {{ $attributes->merge(['class' => 'ml-2 block text-sm text-gray-700 dark:text-gray-300']) }}>
+    {{ $attributes->merge(['class' => 'flex items-center text-sm text-gray-700 dark:text-gray-300']) }}>
     <input type="hidden" name="{{ $name }}" value="0">
     <input type="checkbox" id="{{ $name }}" name="{{ $name }}" value="{{ $value }}"
-        {{ $attributes }} class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
+        {{ $attributes }} class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded mr-1">
     {{ $label }}
 </label>
 

--- a/resources/views/components/forms/input.blade.php
+++ b/resources/views/components/forms/input.blade.php
@@ -10,13 +10,13 @@
 
 @if ($label)
     <label for="{{ $name }}"
-        {{ $attributes->merge(['class' => 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1 ' . $labelClass]) }}>
+        {{ $attributes->merge(['class' => 'block ml-1 text-sm font-medium text-gray-700 dark:text-gray-300 mb-1 ' . $labelClass]) }}>
         {{ $label }}
     </label>
 @endif
 
 <input type="{{ $type }}" id="{{ $name }}" placeholder="{{ $placeholder }}" name="{{ $name }}"
-    {{ $attributes->merge(['class' => 'w-full px-4 py-2 rounded-lg text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent']) }}>
+    {{ $attributes->merge(['class' => 'w-full px-4 py-1.5 rounded-lg text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent']) }}>
 
 @error($name)
     <span class="text-red-500">{{ $message }}</span>


### PR DESCRIPTION
# Visual changes:

## login.blade.php

### Before
<img width="512" height="512" alt="CleanShot 2025-07-24 at 12 46 16@2x" src="https://github.com/user-attachments/assets/e8bd6800-10ee-4b23-96c9-18ac02a4655b" />

### After

<img width="512" height="512" alt="CleanShot 2025-07-24 at 12 46 52@2x" src="https://github.com/user-attachments/assets/14b7e8ba-fa03-4c79-a1e6-20632a6840ec" />

## register.blade.php

### Before

<img width="512" height="512" alt="CleanShot 2025-07-24 at 12 49 12@2x" src="https://github.com/user-attachments/assets/eec43d58-ac4f-4138-96ef-c6ab28b3b02a" />


### After

<img width="512" height="512" alt="CleanShot 2025-07-24 at 12 48 32@2x" src="https://github.com/user-attachments/assets/33a4c0fd-5c56-40e1-9de6-534b7ae9c635" />

