### PR TITLE
Move logout route under the auth middleware

### DIFF
--- a/routes/auth.php
+++ b/routes/auth.php
@@ -29,6 +29,7 @@ Route::middleware('auth')->group(function () {
 
     Route::get('confirm-password', [ConfirmationController::class, 'create'])->name('password.confirm');
     Route::post('confirm-password', [ConfirmationController::class, 'store'])->name('confirmation.store');
+
+    Route::post('logout', [LoginController::class, 'destroy'])->name('logout');
 });
 
-Route::post('logout', [LoginController::class, 'destroy'])->name('logout');


### PR DESCRIPTION
Just moving the logout route under the auth middleware. It makes more sense to keep it protected so only authenticated users can access it.